### PR TITLE
Исправлена ошибка в коде шаблона Одиночка

### DIFF
--- a/pages/Шаблоны-проектирования.md
+++ b/pages/Шаблоны-проектирования.md
@@ -72,20 +72,22 @@ Automobile; во-вторых, если вам нужно при создани�
 class Singleton
 {
     /**
+     * @var Singleton The reference to *Singleton* instance of this class
+     */
+    protected static $instance;
+    
+    /**
      * Returns the *Singleton* instance of this class.
-     *
-     * @staticvar Singleton $instance The *Singleton* instances of this class.
      *
      * @return Singleton The *Singleton* instance.
      */
     public static function getInstance()
     {
-        static $instance = null;
-        if (null === $instance) {
-            $instance = new static;
+        if (null === static::$instance) {
+            static::$instance = new static();
         }
 
-        return $instance;
+        return static::$instance;
     }
 
     /**


### PR DESCRIPTION
Ранее при вызове мотода Singleton::getInstance() происходило постоянное создание нового объекта. Теперь, при последеющих вызоваз, возвращается существующий экземляр.